### PR TITLE
Fix sign in problem

### DIFF
--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -142,15 +142,8 @@ oauth.get("/oauth2/authorize", async (c) => {
 		? `${keycloakPath}?${queryString}`
 		: keycloakPath;
 
-	return proxyToKeycloak(fullPath, c.req.raw);
-});
-
-/**
- * Together with the authorization endpoint, there are multiple resources such as css, js, and images
- * hosted under /resources/ that should all be proxied to Keycloak.
- */
-oauth.get("/resources/*", async (c) => {
-	return proxyToKeycloak(c.req.path, c.req.raw);
+	const redirectUrl = `${keycloakBaseUrl}${fullPath}`;
+	return c.redirect(redirectUrl);
 });
 
 /**


### PR DESCRIPTION
Issue #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * OAuth2 authorization endpoint now redirects clients to the host server on port 8080 instead of proxying.
  * Resource requests that were previously proxied are now served via redirects to the constructed host:port URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->