### PR TITLE
fix: ensure AdminUpdateUserAttributes doesn't reset attributes #25

### DIFF
--- a/src/handlers/users.ts
+++ b/src/handlers/users.ts
@@ -244,6 +244,7 @@ async function adminEnableUser(
 	await keycloakClient.users.update(
 		{ id: user.id! },
 		{
+			...user,
 			enabled: true,
 			attributes: {
 				...user.attributes,
@@ -263,6 +264,7 @@ async function adminDisableUser(
 	await keycloakClient.users.update(
 		{ id: user.id! },
 		{
+			...user,
 			enabled: false,
 			attributes: {
 				...user.attributes,
@@ -408,6 +410,7 @@ async function adminConfirmSignUp(
 	await keycloakClient.users.update(
 		{ id: user.id! },
 		{
+			...user,
 			emailVerified: true,
 			requiredActions,
 			attributes: {
@@ -438,6 +441,7 @@ async function adminResetUserPassword(
 	await keycloakClient.users.update(
 		{ id: user.id! },
 		{
+			...user,
 			requiredActions,
 			attributes: {
 				...user.attributes,

--- a/src/handlers/utils.ts
+++ b/src/handlers/utils.ts
@@ -137,11 +137,26 @@ export function keycloakToCognitoAttributes(
 	}
 
 	// Map custom attributes from Keycloak
+	// Skip standard Cognito attributes (already mapped above) and internal metadata attributes
+	const standardAndInternalAttributes = new Set([
+		// Keycloak top-level fields already mapped above
+		"email",
+		"firstName",
+		"lastName",
+		// Standard Cognito attributes stored in user.attributes but mapped from Keycloak fields
+		"email_verified",
+		"given_name",
+		"family_name",
+		// Internal metadata attributes (not part of Cognito user attributes)
+		"lastModifiedDate",
+		"createdDate",
+	]);
+
 	if (user.attributes) {
 		for (const [key, values] of Object.entries(user.attributes)) {
 			if (values && values.length > 0) {
-				// Skip attributes we've already mapped
-				if (!["email", "firstName", "lastName"].includes(key)) {
+				// Skip standard and internal attributes - only process custom attributes
+				if (!standardAndInternalAttributes.has(key)) {
 					attributes.push({ Name: `custom:${key}`, Value: values[0] });
 				}
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing user attributes when performing partial updates (enable/disable, confirm signup, reset password, single-field updates).
  * Reduce spurious custom attribute mappings so only non-standard fields become custom attributes.

* **Tests**
  * Added integration tests to verify partial user updates and attribute-preservation across operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->